### PR TITLE
feat: freeze contract after 100 blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,17 +63,19 @@ The LYXe token contract is sending `depositData` which will be sliced and passed
 - `withdrawal_credentials` of 32 bytes
 - `signature` of 96 bytes
 - `deposit_data_root` of 32 bytes
+- `supply` of 1 byte
 
 > _Note_: The following checks are performed to ensure a successful deposit:
 
 - the contract should not be _"frozen"_. [See below for more details](#freezeContract-function)
 - `tokensReceived` function MUST be called by the LYXe token contract
 - `amount` value MUST be equal to `32 ether`
-- `depositData.length` MUST be equal to `208`:
+- `depositData.length` MUST be equal to `209`:
   - `pubkey` of 48 bytes
   - `withdrawal_credentials` of 32 bytes
   - `signature` of 96 bytes
   - `deposit_data_root` of 32 bytes
+  - `supply` of 1 byte (value between 0 and 100 where 0 means non-vote)
 
 ### `freezeContract` function
 

--- a/contracts/LUKSOGenesisValidatorsDepositContract.sol
+++ b/contracts/LUKSOGenesisValidatorsDepositContract.sol
@@ -116,7 +116,8 @@ contract LUKSOGenesisValidatorsDepositContract is IERC165 {
      *   • pubkey - the first 48 bytes
      *   • withdrawal_credentials - the following 32 bytes
      *   • signature - the following 96 bytes
-     *   • deposit_data_root - last 32 bytes
+     *   • deposit_data_root - the following 32 bytes
+     *   • supply - that last byte is the initial supply of LYX in million where 0 means non-vote
      */
     function tokensReceived(
         address, /* operator */
@@ -139,7 +140,7 @@ contract LUKSOGenesisValidatorsDepositContract is IERC165 {
             amount == 32 ether,
             "LUKSOGenesisValidatorsDepositContract: Cannot send an amount different from 32 LYXe"
         );
-        // 208 = 48 bytes pubkey + 32 bytes withdrawal_credentials + 96 bytes signature + 32 bytes deposit_data_root
+        // 209 = 48 bytes pubkey + 32 bytes withdrawal_credentials + 96 bytes signature + 32 bytes deposit_data_root + 1 byte for supply
         require(
             depositData.length == (209),
             "LUKSOGenesisValidatorsDepositContract: depositData not encoded properly"

--- a/tests/LUKSOGenesisDepositContract.test.ts
+++ b/tests/LUKSOGenesisDepositContract.test.ts
@@ -118,8 +118,8 @@ describe("Testing LUKSOGenesisValidatorsDepositContract", () => {
       );
     });
 
-    it("should revert when data's length is smaller than 208", async () => {
-      const data = ethers.utils.hexlify(ethers.utils.randomBytes(207));
+    it("should revert when data's length is smaller than 209", async () => {
+      const data = ethers.utils.hexlify(ethers.utils.randomBytes(208));
 
       await expect(
         context.LYXeContract.connect(validators[0]).send(


### PR DESCRIPTION
# What does this PR introduce? 

We use to instantly freeze the contract after calling the `freezeContract()` function. 
It was reported during an audit that owner of the contract could take advantage of it by calling it whenever he wanted. Could portentially let him choose the supply vote value. 

We are now freezing the contract 100 blocks after calling it. 