### PR TITLE
chore: rename `constant` variables in UPPER_CASE_WITH_UNDERSCORE

### DIFF
--- a/contracts/LUKSOGenesisValidatorsDepositContract.sol
+++ b/contracts/LUKSOGenesisValidatorsDepositContract.sol
@@ -15,17 +15,17 @@ import {IERC1820Registry} from "./interfaces/IERC1820Registry.sol";
 
 contract LUKSOGenesisValidatorsDepositContract is IERC165 {
     // The address of the LYXe token contract.
-    address constant LYXeAddress = 0xA8b919680258d369114910511cc87595aec0be6D;
+    address constant LYX_TOKEN_CONTRACT_ADDRESS = 0xA8b919680258d369114910511cc87595aec0be6D;
 
     // The address of the registry contract (ERC1820 Registry).
-    address constant registryAddress = 0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24;
+    address constant REGISTRY_ADDRESS = 0x1820a4B7618BdE71Dce8cdc73aAB6C95905faD24;
 
     // The hash of the interface of the contract that receives tokens.
     bytes32 constant TOKENS_RECIPIENT_INTERFACE_HASH =
         0xb281fc8c12954d22544db45de3159a39272895b169a852b314f9cc762e44c53b;
 
     // _to_little_endian_64(uint64(32 ether / 1 gwei))
-    bytes constant amount_to_little_endian_64 = hex"0040597307000000";
+    bytes constant AMOUNT_TO_LITTLE_ENDIAN_64 = hex"0040597307000000";
 
     // The current number of deposits in the contract.
     uint256 internal deposit_count;
@@ -90,7 +90,7 @@ contract LUKSOGenesisValidatorsDepositContract is IERC165 {
         isContractFrozen = false;
 
         // Set this contract as the implementer of the tokens recipient interface in the registry contract.
-        IERC1820Registry(registryAddress).setInterfaceImplementer(
+        IERC1820Registry(REGISTRY_ADDRESS).setInterfaceImplementer(
             address(this),
             TOKENS_RECIPIENT_INTERFACE_HASH,
             address(this)
@@ -129,7 +129,7 @@ contract LUKSOGenesisValidatorsDepositContract is IERC165 {
         );
         // Check is the caller is the LYXe token contract
         require(
-            msg.sender == LYXeAddress,
+            msg.sender == LYX_TOKEN_CONTRACT_ADDRESS,
             "LUKSOGenesisValidatorsDepositContract: Not called on LYXe transfer"
         );
         // Check if the amount is 32 LYXe
@@ -186,7 +186,7 @@ contract LUKSOGenesisValidatorsDepositContract is IERC165 {
         bytes32 computedDataRoot = keccak256(
             abi.encodePacked(
                 keccak256(abi.encodePacked(pubkey_root, withdrawal_credentials)),
-                keccak256(abi.encodePacked(amount_to_little_endian_64, bytes24(0), signature_root))
+                keccak256(abi.encodePacked(AMOUNT_TO_LITTLE_ENDIAN_64, bytes24(0), signature_root))
             )
         );
 
@@ -200,7 +200,7 @@ contract LUKSOGenesisValidatorsDepositContract is IERC165 {
         emit DepositEvent(
             pubkey,
             withdrawal_credentials,
-            amount_to_little_endian_64,
+            AMOUNT_TO_LITTLE_ENDIAN_64,
             signature,
             deposit_count
         );


### PR DESCRIPTION
# What does this PR introduce?

Rename the following `constant` variables in UPPER_CASE for consistency according to naming conventions.

- `LYXeAddress` -> `LYX_TOKEN_CONTRACT_ADDRESS`
- `registryAddress` -> `REGISTRY_ADDRESS`
- `amount_to_little_endian_64` -> `AMOUNT_TO_LITTLE_ENDIAN_64`

